### PR TITLE
[OC-33] 戻るボタンが正常に動くように修正

### DIFF
--- a/src/components/OrigamiPost/atoms/inputStepObjectAtom.ts
+++ b/src/components/OrigamiPost/atoms/inputStepObjectAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from "jotai";
 import { Board, BaseStep } from "@/types/model";
 
-const initialBoard: Board = [
+export const initialBoard: Board = [
   [20, 20, 0],
   [-20, 20, 0],
   [-20, -20, 0],
@@ -21,6 +21,7 @@ export type InputStepObject = {
 export const inputStepObjectAtom = atom<InputStepObject>({
   "1": {
     type: "Base",
+    initialBoards: [initialBoard],
     selectedPoints: [],
     rightBoards: [],
     leftBoards: [],
@@ -30,7 +31,7 @@ export const inputStepObjectAtom = atom<InputStepObject>({
     isFoldingDirectionFront: true,
     foldingAngle: 180,
     description: "",
-    fixBoards: [initialBoard],
+    fixBoards: [],
     moveBoards: [],
     rotateAxis: [],
   },

--- a/src/components/OrigamiPost/hooks/useDecideFoldMethod/index.tsx
+++ b/src/components/OrigamiPost/hooks/useDecideFoldMethod/index.tsx
@@ -4,18 +4,25 @@
  *
  */
 
-import { Point } from "@/types/model";
+import { Board, Point } from "@/types/model";
 import { rotateBoards } from "../../logics/rotateBoards";
 import { decideNewProcedure } from "../../logics/decideNewProcedure";
 import { currentStepAtom } from "../../atoms/currentStepAtom";
 import { inputStepObjectAtom } from "../../atoms/inputStepObjectAtom";
 import { useAtom } from "jotai";
 
-type UseDecideFoldMethod = () => {
+type UseDecideFoldMethod = (props: {
+  // TODO: ここの命名の見直し
+  fixBoards: Board[];
+  moveBoards: Board[];
+}) => {
   handleDecideFoldMethod: () => void;
 };
 
-export const useDecideFoldMethod: UseDecideFoldMethod = () => {
+export const useDecideFoldMethod: UseDecideFoldMethod = ({
+  fixBoards,
+  moveBoards,
+}) => {
   const [currentStep, setCurrentStep] = useAtom(currentStepAtom);
   const [inputStepObject, setInputStepObject] = useAtom(inputStepObjectAtom);
 
@@ -23,8 +30,6 @@ export const useDecideFoldMethod: UseDecideFoldMethod = () => {
 
   const step = inputStepObject[procedureIndex.toString()];
 
-  const fixBoards = step.fixBoards;
-  const moveBoards = step.moveBoards;
   const leftBoards = step.leftBoards;
   const rightBoards = step.rightBoards;
   const numberOfMoveBoards = step.numberOfMoveBoards;

--- a/src/components/OrigamiPost/hooks/useDecideFoldMethod/index.tsx
+++ b/src/components/OrigamiPost/hooks/useDecideFoldMethod/index.tsx
@@ -106,6 +106,7 @@ export const useDecideFoldMethod: UseDecideFoldMethod = ({
         },
         [procedureIndex + 1]: {
           type: "Base",
+          initialBoards: roundedBoards,
           selectedPoints: [],
           rightBoards: [],
           leftBoards: [],
@@ -114,7 +115,7 @@ export const useDecideFoldMethod: UseDecideFoldMethod = ({
           numberOfMoveBoards: 0,
           maxNumberOfMoveBoards: 0,
           isFoldingDirectionFront: true,
-          fixBoards: roundedBoards,
+          fixBoards: [],
           moveBoards: [],
           foldingAngle: 180,
           description: "",

--- a/src/components/OrigamiPost/hooks/useDecideRotateAxis/index.tsx
+++ b/src/components/OrigamiPost/hooks/useDecideRotateAxis/index.tsx
@@ -17,7 +17,7 @@ export const useDecideRotateAxis: UseDecideRotateAxis = () => {
   const step = inputStepObject[procedureIndex.toString()];
 
   const selectedPoints = step.selectedPoints;
-  const fixBoards = inputStepObject[procedureIndex.toString()].fixBoards;
+  const initialBoards = step.initialBoards;
 
   const handleDecideRotateAxis = async () => {
     try {
@@ -28,7 +28,7 @@ export const useDecideRotateAxis: UseDecideRotateAxis = () => {
       const axis: RotateAxis = [[...selectedPoints[0]], [...selectedPoints[1]]];
 
       // step2:板を分割するか、回転軸が左右どちらに属するかを判定
-      const { lefts, rights } = processBoards(fixBoards, axis);
+      const { lefts, rights } = processBoards(initialBoards, axis);
 
       // step3:状態を更新
       setInputStepObject({

--- a/src/components/OrigamiPost/hooks/useSelectPoints/index.tsx
+++ b/src/components/OrigamiPost/hooks/useSelectPoints/index.tsx
@@ -37,7 +37,7 @@ export const useSelectPoints: UseSelectPoints = ({
   const procedureIndex = currentStep.procedureIndex;
   const step = inputStepObject[procedureIndex.toString()];
 
-  const fixBoards = step.fixBoards;
+  const initialBoards = step.initialBoards;
   const selectedPoints = step.selectedPoints;
 
   useInitialRender({
@@ -45,7 +45,7 @@ export const useSelectPoints: UseSelectPoints = ({
     sceneRef,
     rendererRef,
     cameraRef,
-    fixBoards,
+    initialBoards,
     selectedPoints,
     origamiColor,
   });
@@ -57,7 +57,7 @@ export const useSelectPoints: UseSelectPoints = ({
     cameraRef,
     rendererRef,
     raycasterRef,
-    fixBoards,
+    initialBoards,
     setHighlightedVertex,
   });
 

--- a/src/components/OrigamiPost/hooks/useSelectPoints/useInitialRender.ts
+++ b/src/components/OrigamiPost/hooks/useSelectPoints/useInitialRender.ts
@@ -9,14 +9,14 @@ import { useEffect } from "react";
 import * as THREE from "three";
 import { renderSelectedPoint, renderSnapPoint } from "./renderPoint";
 import { renderBoard } from "../../logics/renderBoard";
-import { Point } from "@/types/model";
+import { Point, Board } from "@/types/model";
 
 type UseInitialRender = (props: {
   inputStep: string;
   sceneRef: React.MutableRefObject<THREE.Scene | null>;
   rendererRef: React.MutableRefObject<THREE.WebGLRenderer | null>;
   cameraRef: React.MutableRefObject<THREE.PerspectiveCamera | null>;
-  fixBoards: Point[][];
+  initialBoards: Board[];
   selectedPoints: Point[];
   origamiColor: string;
 }) => void;
@@ -26,7 +26,7 @@ export const useInitialRender: UseInitialRender = ({
   sceneRef,
   rendererRef,
   cameraRef,
-  fixBoards,
+  initialBoards,
   selectedPoints,
   origamiColor,
 }) => {
@@ -45,7 +45,7 @@ export const useInitialRender: UseInitialRender = ({
     });
 
     // boardsを描画
-    fixBoards.forEach((board) => {
+    initialBoards.forEach((board) => {
       renderBoard({ scene, board, color: origamiColor });
 
       // 頂点のスナップポイントを描画
@@ -76,7 +76,7 @@ export const useInitialRender: UseInitialRender = ({
     sceneRef,
     rendererRef,
     cameraRef,
-    fixBoards,
+    initialBoards,
     origamiColor,
     selectedPoints,
   ]);

--- a/src/components/OrigamiPost/hooks/useSelectPoints/useMouseMove.ts
+++ b/src/components/OrigamiPost/hooks/useSelectPoints/useMouseMove.ts
@@ -9,7 +9,7 @@
 
 import { useEffect } from "react";
 import * as THREE from "three";
-import { Point } from "@/types/model";
+import { Board } from "@/types/model";
 import { renderHighlightPoint } from "./renderPoint";
 
 type UseMouseMove = (props: {
@@ -19,7 +19,7 @@ type UseMouseMove = (props: {
   cameraRef: React.MutableRefObject<THREE.PerspectiveCamera | null>;
   rendererRef: React.MutableRefObject<THREE.WebGLRenderer | null>;
   raycasterRef: React.MutableRefObject<THREE.Raycaster | null>;
-  fixBoards: Point[][];
+  initialBoards: Board[];
   setHighlightedVertex: (vertex: THREE.Vector3 | null) => void;
 }) => void;
 
@@ -30,7 +30,7 @@ export const useMouseMove: UseMouseMove = ({
   cameraRef,
   rendererRef,
   raycasterRef,
-  fixBoards,
+  initialBoards,
   setHighlightedVertex,
 }) => {
   const SNAP_THRESHOLD = 0.1; // スナップする距離の閾値
@@ -59,7 +59,7 @@ export const useMouseMove: UseMouseMove = ({
       let minDistance = Infinity;
 
       // 頂点と辺の中心点のチェック
-      fixBoards.forEach((board) => {
+      initialBoards.forEach((board) => {
         // 頂点のチェック
         board.forEach((vertex) => {
           const vertexVector = new THREE.Vector3(
@@ -144,7 +144,7 @@ export const useMouseMove: UseMouseMove = ({
     cameraRef,
     rendererRef,
     raycasterRef,
-    fixBoards,
+    initialBoards,
     setHighlightedVertex,
   ]);
 };

--- a/src/components/OrigamiPost/hooks/useSelectSideAndNumberOfBoards/index.tsx
+++ b/src/components/OrigamiPost/hooks/useSelectSideAndNumberOfBoards/index.tsx
@@ -3,86 +3,88 @@ import { inputStepObjectAtom } from "../../atoms/inputStepObjectAtom";
 import { useAtom, useAtomValue } from "jotai";
 import { calculateSelectedBoardCount } from "./calculateSelectedBoardCount";
 import { processBoardsForFolding } from "./processBoardsForFolding";
+import { Board } from "@/types/model";
 
-type UseSelectSideAndNumberOfBoards = () => {
+type UseSelectSideAndNumberOfBoards = (props: {
+  setFoldBoards: React.Dispatch<React.SetStateAction<Board[]>>;
+  setNotFoldBoards: React.Dispatch<React.SetStateAction<Board[]>>;
+}) => {
   handleFoldFrontSide: () => void;
   handleFoldBackSide: () => void;
-  numberOfMoveBoards: number;
-  maxNumberOfMoveBoards: number;
-  isFoldingDirectionFront: boolean;
 };
 
-export const useSelectSideAndNumberOfBoards: UseSelectSideAndNumberOfBoards =
-  () => {
-    const currentStep = useAtomValue(currentStepAtom);
-    const [inputStepObject, setInputStepObject] = useAtom(inputStepObjectAtom);
+export const useSelectSideAndNumberOfBoards: UseSelectSideAndNumberOfBoards = ({
+  setFoldBoards,
+  setNotFoldBoards,
+}) => {
+  const currentStep = useAtomValue(currentStepAtom);
+  const [inputStepObject, setInputStepObject] = useAtom(inputStepObjectAtom);
 
-    const procedureIndex = currentStep.procedureIndex;
-    const step = inputStepObject[procedureIndex.toString()];
+  const procedureIndex = currentStep.procedureIndex;
+  const step = inputStepObject[procedureIndex.toString()];
 
-    const isMoveBoardsRight = step.isMoveBoardsRight;
-    const leftBoards = step.leftBoards;
-    const rightBoards = step.rightBoards;
-    const isFoldingDirectionFront = step.isFoldingDirectionFront;
-    const numberOfMoveBoards = step.numberOfMoveBoards;
+  const isMoveBoardsRight = step.isMoveBoardsRight;
+  const leftBoards = step.leftBoards;
+  const rightBoards = step.rightBoards;
+  const isFoldingDirectionFront = step.isFoldingDirectionFront;
+  const numberOfMoveBoards = step.numberOfMoveBoards;
 
-    const targetBoards = isMoveBoardsRight ? rightBoards : leftBoards;
-    const maxNumberOfMoveBoards = targetBoards.filter((board) =>
-      board.every((point) => point[2] === board[0][2])
-    ).length;
+  const targetBoards = isMoveBoardsRight ? rightBoards : leftBoards;
+  const maxNumberOfMoveBoards = targetBoards.filter((board) =>
+    board.every((point) => point[2] === board[0][2])
+  ).length;
 
-    // z座標の移動量
-    // 手前に折る場合は+0.001、奥に折る場合は-0.001移動させる
-    const MOVE_Z_OFFSET_FRONT = 0.001;
-    const MOVE_Z_OFFSET_BACK = -0.001;
+  // z座標の移動量
+  // 手前に折る場合は+0.001、奥に折る場合は-0.001移動させる
+  const MOVE_Z_OFFSET_FRONT = 0.001;
+  const MOVE_Z_OFFSET_BACK = -0.001;
 
-    // 手前に折る
-    const handleFoldFrontSide = () => {
-      handleFolding(true, MOVE_Z_OFFSET_FRONT);
-    };
-
-    // 奥に折る
-    const handleFoldBackSide = () => {
-      handleFolding(false, MOVE_Z_OFFSET_BACK);
-    };
-
-    const handleFolding = (isFront: boolean, zOffset: number) => {
-      // step1:折る枚数を計算
-      const selectedBoardCount = calculateSelectedBoardCount(
-        isFront ? !isFoldingDirectionFront : isFoldingDirectionFront,
-        numberOfMoveBoards,
-        maxNumberOfMoveBoards
-      );
-
-      // step2:板を分類し、折る板と折らない板を処理
-      const { foldBoards, notFoldBoards } = processBoardsForFolding(
-        targetBoards,
-        selectedBoardCount,
-        zOffset
-      );
-
-      // step3:折る方向を更新
-      setInputStepObject((prev) => ({
-        ...prev,
-        [procedureIndex.toString()]: {
-          ...prev[procedureIndex.toString()],
-          moveBoards: foldBoards,
-          fixBoards: [
-            ...(isMoveBoardsRight ? leftBoards : rightBoards),
-            ...notFoldBoards,
-          ],
-          numberOfMoveBoards: selectedBoardCount,
-          isFoldingDirectionFront: isFront,
-          maxNumberOfMoveBoards,
-        },
-      }));
-    };
-
-    return {
-      handleFoldFrontSide,
-      handleFoldBackSide,
-      numberOfMoveBoards,
-      maxNumberOfMoveBoards,
-      isFoldingDirectionFront,
-    };
+  // 手前に折る
+  const handleFoldFrontSide = () => {
+    handleFolding(true, MOVE_Z_OFFSET_FRONT);
   };
+
+  // 奥に折る
+  const handleFoldBackSide = () => {
+    handleFolding(false, MOVE_Z_OFFSET_BACK);
+  };
+
+  const handleFolding = (isFront: boolean, zOffset: number) => {
+    // step1:折る枚数を計算
+    const selectedBoardCount = calculateSelectedBoardCount(
+      isFront ? !isFoldingDirectionFront : isFoldingDirectionFront,
+      numberOfMoveBoards,
+      maxNumberOfMoveBoards
+    );
+
+    // step2:板を分類し、折る板と折らない板を処理
+    const { foldBoards, notFoldBoards } = processBoardsForFolding(
+      targetBoards,
+      selectedBoardCount,
+      zOffset
+    );
+
+    setFoldBoards(foldBoards);
+    setNotFoldBoards([
+      ...(isMoveBoardsRight ? leftBoards : rightBoards),
+      ...notFoldBoards,
+    ]);
+
+    // step3:折る方向を更新
+    // TODO: ここでInputStepObjectを更新しないようにしたい
+    setInputStepObject((prev) => ({
+      ...prev,
+      [procedureIndex.toString()]: {
+        ...prev[procedureIndex.toString()],
+        numberOfMoveBoards: selectedBoardCount,
+        isFoldingDirectionFront: isFront,
+        maxNumberOfMoveBoards,
+      },
+    }));
+  };
+
+  return {
+    handleFoldFrontSide,
+    handleFoldBackSide,
+  };
+};

--- a/src/components/OrigamiPost/index.tsx
+++ b/src/components/OrigamiPost/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styles from "./index.module.scss";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/Addons.js";
@@ -22,6 +22,7 @@ import { inputStepObjectAtom } from "./atoms/inputStepObjectAtom";
 import { useAtom } from "jotai";
 import { useCancelFoldTarget } from "./hooks/useCancelFoldTarget";
 import { PopupType } from "@/types/popup";
+import { Board } from "@/types/model";
 
 export const OrigamiPost = () => {
   // 常に保持しておきたい変数
@@ -122,17 +123,36 @@ export const OrigamiPost = () => {
   });
 
   // step3：板を折る方向と枚数を決定
+
+  const [foldBoards, setFoldBoards] = useState<Board[]>([]);
+  const [notFoldBoards, setNotFoldBoards] = useState<Board[]>([]);
+
+  const rightBoards = step.rightBoards;
+  const leftBoards = step.leftBoards;
+
+  useEffect(() => {
+    setFoldBoards([]);
+    setNotFoldBoards([...rightBoards, ...leftBoards]);
+  }, [rightBoards, leftBoards]);
+
   const { handleFoldFrontSide, handleFoldBackSide } =
-    useSelectSideAndNumberOfBoards();
+    useSelectSideAndNumberOfBoards({
+      setFoldBoards,
+      setNotFoldBoards,
+    });
 
   // 回転に応じて板を描画
   useRotateBoards({
     sceneRef,
     origamiColor,
+    foldBoards,
+    notFoldBoards,
   });
 
-  const { handleDecideFoldMethod }: { handleDecideFoldMethod: () => void } =
-    useDecideFoldMethod();
+  const { handleDecideFoldMethod } = useDecideFoldMethod({
+    fixBoards: notFoldBoards,
+    moveBoards: foldBoards,
+  });
 
   const { handleRegisterOrigami } = useRegisterOrigami({
     origamiName,

--- a/src/components/OrigamiPost/logics/decideNewProcedure.ts
+++ b/src/components/OrigamiPost/logics/decideNewProcedure.ts
@@ -106,7 +106,7 @@ export const decideNewProcedure: DecideNewProcedure = ({
   }
 
   /**
-   * selectedPoints, rightBoards, leftBoardsは、atomから取得しないといけない
+   * selectedPoints, rightBoards, leftBoards, initialBoardsは、atomから取得しないといけない
    * buildを通すために一旦ここでは空にしておく
    */
   const newProcedure: Procedure[number] = {
@@ -115,6 +115,7 @@ export const decideNewProcedure: DecideNewProcedure = ({
     fixBoards: [...fixBoards, ...notFoldBoards],
     moveBoards: foldBoards,
     rotateAxis: sortedRotateAxis,
+    initialBoards: [],
     selectedPoints: [],
     rightBoards: [],
     leftBoards: [],

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -10,6 +10,7 @@ export type BaseStep = {
   moveBoards: Board[];
   rotateAxis: RotateAxis;
   // 折り方入力の際に必要なデータ
+  initialBoards: Board[];
   selectedPoints: Point[];
   rightBoards: Board[];
   leftBoards: Board[];


### PR DESCRIPTION
# [OC-33] 戻るボタンが正常に動くように修正

## 概要
今回は「戻る」ボタンの動作が正常になるよう修正を行いました。

- SegmentedControlについては、依然としてバグが残っています。
- また、折り紙登録時にも正しくデータが登録されない問題があります。

これらについては、別のPRで対応します。`bug/origami-input`というブランチを作成したので、このブランチに修正をあつめ、折り紙入力が正常に動くようになったら`main`にマージします。

## 変更内容
1. 「次へ」ボタンを押した時のみ、InputStepの内容を更新するように修正
    - これまで状態の更新が様々な場所で発生し、管理が煩雑になっていました。
    - 今回の修正で、状態更新のタイミングを「次へ」ボタン押下時に限定しました。
2. InputStepObjectに`initialBoards`パラメータを追加
    - 折り紙作成の途中で、`fixBoards`や`moveBoards`が何度も更新されてしまう問題がありました。
    - 各手順で折り紙を折る際の「最初の状態」として`initialBoards`を定義し、状態の一貫性を保つようにしました。

## スクリーンショット
（必要に応じて追加してください）

## 備考
- SegmentedControlや折り紙登録時の不具合は、今後別PRで対応予定です。
