### PR TITLE
[OC-64] 折っている面をわかりやすくする

### DIFF
--- a/src/components/OrigamiDetail/Three/index.tsx
+++ b/src/components/OrigamiDetail/Three/index.tsx
@@ -8,6 +8,7 @@ import { OrbitControls } from "three/examples/jsm/Addons.js";
 import { LineGeometry } from "three/examples/jsm/Addons.js";
 import { LineMaterial } from "three/examples/jsm/Addons.js";
 import { Line2 } from "three/examples/jsm/Addons.js";
+import { getOutlineColor } from "@/utils/modify-color";
 
 type Props = {
   procedure: Procedure;
@@ -248,16 +249,4 @@ export const Three: React.FC<Props> = ({
   }, [foldAngle, stepObject]);
 
   return <canvas ref={canvasRef} id="canvas" className={styles.model}></canvas>;
-};
-
-// 色のアウトラインを取得する関数
-const getOutlineColor = (hexColor: string): THREE.Color => {
-  const color = new THREE.Color(hexColor);
-  const hsl = { h: 0, s: 0, l: 0 };
-  color.getHSL(hsl);
-
-  // 色相(h)を180度回転させ、補色を取得 (0.5を加算)
-  hsl.h = (hsl.h + 0.5) % 1.0;
-
-  return new THREE.Color().setHSL(hsl.h, hsl.s, hsl.l);
 };

--- a/src/components/OrigamiDetail/Three/index.tsx
+++ b/src/components/OrigamiDetail/Three/index.tsx
@@ -36,6 +36,9 @@ export const Three: React.FC<Props> = ({
 
   const stepObject = procedure[procedureIndex.toString()]; // 1ステップ分
 
+  // 枠線の取得
+  const outlineColor = getOutlineColor(color);
+
   // シーンの初期化
   useEffect(() => {
     if (sceneRef.current) return; // シーンが既に初期化されている場合は何もしない
@@ -113,7 +116,10 @@ export const Three: React.FC<Props> = ({
     scene.clear();
 
     // そのままの板と、回転後の板を保持
-    const boards = [...stepObject.fixBoards];
+    const boards: { points: Board; isMove: boolean }[] = [];
+    stepObject.fixBoards.forEach((b) =>
+      boards.push({ points: b, isMove: false })
+    );
     const holds_line = [];
     const theta = THREE.MathUtils.degToRad(foldAngle);
 
@@ -141,7 +147,7 @@ export const Three: React.FC<Props> = ({
             rotateNode.add(subNode);
             return [rotateNode.x, rotateNode.y, rotateNode.z];
           });
-          boards.push(newBoard as Board);
+          boards.push({ points: newBoard as Board, isMove: true });
         }
 
         break;
@@ -177,7 +183,7 @@ export const Three: React.FC<Props> = ({
             const node = new THREE.Vector3(...nodes[board[j]]);
             newBoard.push([node.x, node.y, node.z]);
           }
-          boards.push(newBoard as Board);
+          boards.push({ points: newBoard as Board, isMove: true });
         }
 
         break;
@@ -187,7 +193,7 @@ export const Three: React.FC<Props> = ({
     }
 
     // 板を描画
-    boards.forEach((board) => {
+    boards.forEach(({ points: board, isMove }) => {
       const geometry = new THREE.BufferGeometry();
       geometry.setAttribute(
         "position",
@@ -204,44 +210,54 @@ export const Three: React.FC<Props> = ({
       const backMesh = new THREE.Mesh(geometry, backMaterial);
       scene.add(frontMesh);
       scene.add(backMesh);
-      const EdgesGeometry = new THREE.EdgesGeometry(geometry);
-      const wireframeMaterial = new THREE.LineBasicMaterial({
-        color: 0x000000, // ワイヤーフレームの色
-        linewidth: 1,
+      const edgesGeometry = new THREE.EdgesGeometry(geometry);
+      // 頂点座標の配列を作成
+      const positionAttr = edgesGeometry.getAttribute("position");
+      const positions = new Float32Array(positionAttr.array);
+
+      // LineGeometry にセット
+      const lineGeometry = new LineGeometry();
+      lineGeometry.setPositions(positions);
+
+      // 枠線の設定
+      const lineMaterial = new LineMaterial({
+        color: isMove ? outlineColor.getHex() : 0x000000,
+        linewidth: isMove ? 2 : 0.5,
+        worldUnits: false,
+        vertexColors: false,
       });
-      const wireframe = new THREE.LineSegments(
-        EdgesGeometry,
-        wireframeMaterial
-      );
-      scene.add(wireframe);
+      // LineMaterial の解像度を設定
+      lineMaterial.resolution.set(window.innerWidth, window.innerHeight);
+
+      // 枠線を描画
+      const outline = new Line2(lineGeometry, lineMaterial);
+      scene.add(outline);
     });
 
     // 折り目を描画
     holds_line.forEach((line) => {
       const geometry = new LineGeometry();
       geometry.setPositions(line);
-      const colorStart = new THREE.Color(0xff0000);
-      const colorEnd = new THREE.Color(0x0000ff);
-
-      const colors = [
-        colorStart.r,
-        colorStart.g,
-        colorStart.b,
-        colorEnd.r,
-        colorEnd.g,
-        colorEnd.b,
-      ];
-      geometry.setColors(colors);
       const lineMaterial = new LineMaterial({
-        linewidth: 4,
-        vertexColors: true,
-        worldUnits: false,
+        linewidth: 2,
+        color: outlineColor.getHex(),
       });
       const lineMesh = new Line2(geometry, lineMaterial);
-      //lineMesh.computeLineDistances();
       scene.add(lineMesh);
     });
   }, [foldAngle, stepObject]);
 
   return <canvas ref={canvasRef} id="canvas" className={styles.model}></canvas>;
+};
+
+// 色のアウトラインを取得する関数
+const getOutlineColor = (hexColor: string): THREE.Color => {
+  const color = new THREE.Color(hexColor);
+  const hsl = { h: 0, s: 0, l: 0 };
+  color.getHSL(hsl);
+
+  // 色相(h)を180度回転させ、補色を取得 (0.5を加算)
+  hsl.h = (hsl.h + 0.5) % 1.0;
+
+  return new THREE.Color().setHSL(hsl.h, hsl.s, hsl.l);
 };

--- a/src/components/OrigamiDetail/Three/index.tsx
+++ b/src/components/OrigamiDetail/Three/index.tsx
@@ -220,11 +220,25 @@ export const Three: React.FC<Props> = ({
     holds_line.forEach((line) => {
       const geometry = new LineGeometry();
       geometry.setPositions(line);
+      const colorStart = new THREE.Color(0xff0000);
+      const colorEnd = new THREE.Color(0x0000ff);
+
+      const colors = [
+        colorStart.r,
+        colorStart.g,
+        colorStart.b,
+        colorEnd.r,
+        colorEnd.g,
+        colorEnd.b,
+      ];
+      geometry.setColors(colors);
       const lineMaterial = new LineMaterial({
-        color: 0xff00ff,
-        linewidth: 3,
+        linewidth: 4,
+        vertexColors: true,
+        worldUnits: false,
       });
       const lineMesh = new Line2(geometry, lineMaterial);
+      //lineMesh.computeLineDistances();
       scene.add(lineMesh);
     });
   }, [foldAngle, stepObject]);

--- a/src/utils/modify-color.ts
+++ b/src/utils/modify-color.ts
@@ -1,0 +1,13 @@
+import * as THREE from "three";
+
+// 色のアウトラインを取得する関数
+export const getOutlineColor = (hexColor: string): THREE.Color => {
+  const color = new THREE.Color(hexColor);
+  const hsl = { h: 0, s: 0, l: 0 };
+  color.getHSL(hsl);
+
+  // 色相(h)を180度回転させ、補色を取得 (0.5を加算)
+  hsl.h = (hsl.h + 0.5) % 1.0;
+
+  return new THREE.Color().setHSL(hsl.h, hsl.s, hsl.l);
+};


### PR DESCRIPTION
# タイトル
[OC-64] 折っている面をわかりやすくする

## 概要
「動かした板」と「固定された板」で枠線の色や太さを分け、折っている面が強調されるようにしました。
## 変更内容
- Threeコンポーネントで板（Board）のデータ構造を、isMove（面が動いているかどうか）フラグ付きのオブジェクト配列に変更しました。
- 枠線の描画処理を見直し、通常板と動いた板で枠線色や太さを動的に変更するようにしました。動いた板は補色＆太め、固定板は黒＆細めになります。
- 折り紙がどのような色でも視認性を向上させるため、枠線色の計算用ユーティリティ関数getOutlineColorを新規作成し、補色を返すようにしました。
- 折り目のライン描画も枠線色（補色）を適用するように変更されました。
- EdgesGeometry→Line2/LineMaterialによる描画へ移行し、描画品質や柔軟性が向上しています。

## スクリーンショット
<img width="525" height="369" alt="スクリーンショット 2025-07-26 11 53 24" src="https://github.com/user-attachments/assets/7e6e99ba-34ad-4fe3-ad10-b0823af7f3da" />
<img width="953" height="824" alt="スクリーンショット 2025-07-26 11 52 48" src="https://github.com/user-attachments/assets/fc2be5b8-b6bb-4d5e-8c73-41d4029a1397" />

↓動画
https://github.com/user-attachments/assets/0dd5e555-e05d-4864-b105-eb41d48359ca
https://github.com/user-attachments/assets/28acbb5f-61f2-486e-b4ad-657543bd3007

## 備考
- 一旦補色を強調色として設定しましたが、もっといいアイデアがあれば教えてください。
