### PR TITLE
create dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pnpm" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 概要

dependabot の設定をした。
古いpackageには自動でPRが発行されるようになる。

### Why

package の update をする仕組みがないため。
