### PR TITLE
:sparkles: feat: react-ariaベースのTextInputコンポーネントを追加

### DIFF
--- a/packages/design-system/src/components/TextInput/TextInput.mdx
+++ b/packages/design-system/src/components/TextInput/TextInput.mdx
@@ -1,0 +1,74 @@
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as TextInputStories from "./TextInput.stories";
+
+<Meta of={TextInputStories} />
+
+# TextInput
+
+1行のテキスト入力欄です。ラベル・サポートテキスト・エラーメッセージを1つのコンポーネントにまとめており、[react-aria-components](https://react-spectrum.adobe.com/react-aria/TextField.html) をベースに、ラベルとの関連付け・エラーの読み上げなどのアクセシビリティを担保しています。
+
+<Canvas of={TextInputStories.Default} />
+
+<Controls />
+
+## 使用原則
+
+### ラベルと必須表現
+
+<Canvas of={TextInputStories.Required} />
+
+- 必須の入力欄には `required` を指定します。ラベルの後ろに**「（必須）」が赤文字で表示**されます。
+- アスタリスク（`*`）による必須表現は使用しません。記号は意味が伝わりにくく、スクリーンリーダー向けに別途 `aria-label` を用意する必要が生じるためです。「（必須）」という文字ならば、視覚的にもスクリーンリーダーにもそのまま伝わります。
+
+### サポートテキスト（description）
+
+<Canvas of={TextInputStories.WithDescription} />
+
+- 「全角で入力してください」のような**入力ルールの説明は、必ず description で行います**。プレースホルダーで説明してはいけません。
+- サポートテキストは**ラベルと入力欄の間**に表示されます。エラーメッセージは入力欄の下に表示されるため、入力欄の下にテキストが2つ並んで「どちらを読めばよいのか」が分かりづらくなることを避けています。
+- プレースホルダーは入力を始めると消えてしまうため、入力中・入力後にルールを確認できなくなります。説明は常に表示される description が担い、プレースホルダーはあくまで**入力例を示すためだけ**に使う、という役割分担を徹底します。
+
+### プレースホルダー
+
+- プレースホルダーには**入力例のみ**を指定します。`placeholder="例：山田 太郎"` のように、値が入力例であることが伝わる形（「例：」を冠するなど）で渡してください。表示されている文字が実際の入力値ではなく未入力状態の例であることが、色のコントラストに頼らず文字情報として伝わります。
+- プレースホルダーは補助情報です。**なくても伝わる場合は省略**し、プレースホルダーがなくても入力できるよう、ラベルと description だけで完結する設計にします。
+- プレースホルダーの文字色は専用トークン `--text-placeholder`（`neutral-40` / #757575）です。白背景とのコントラスト比は約 4.6:1 で WCAG AA（1.4.3 Contrast (Minimum) の 4.5:1）を満たしつつ、入力値の文字色 `--text-default`（#1f1f1f）より明るい色にすることで、色の濃さでも入力値と区別できるようにしています。
+
+### 入力目的の指定（autoComplete / type / inputMode）
+
+<Canvas of={TextInputStories.Email} />
+
+- 氏名・メール・電話番号など**入力目的が既知の欄には `autoComplete` を必ず指定**します（例：`autoComplete="email"`）。ブラウザの自動入力が効き、認知・運動に配慮が必要なユーザーの入力負担を下げられます（WCAG 1.3.5 Identify Input Purpose）。
+- メール・電話・数値などは `type`（`email` / `tel` / `number` 等）を指定します。バリデーションやモバイルのキーボード種別に反映されます。
+- 必要に応じて `inputMode` でソフトウェアキーボードの種別を明示します（例：`inputMode="email"`）。
+- これらは props としてそのまま `<input>` に渡されます。
+
+### エラーメッセージ
+
+<Canvas of={TextInputStories.WithError} />
+
+- `errorMessage` を渡すと、入力欄がエラー状態になり、メッセージが入力欄に関連付けてスクリーンリーダーにも通知されます。エラー状態とメッセージ表示は常に連動し、片方だけになることはありません。
+- エラーは**赤枠だけでなく警告アイコンを併記**します。色だけに頼らずエラーであることを伝えるためです（WCAG 1.4.1 Use of Color）。
+- エラーメッセージの文面は、次の**3ステップをすべて満たす**ように書きます。
+  1. **通知**: エラーが発生したことを伝える（例：「エラー：」）
+  2. **説明**: どのようなエラーなのかを伝える（例：「お名前が入力されていません。」）
+  3. **リカバリー**: どうすれば解消できるかを伝える（例：「お名前を全角で入力してください。」）
+- 全体では「エラー：お名前が入力されていません。お名前を全角で入力してください。」のような文面になります。エラーの特定と修正方法の提示は WCAG の達成基準でもあり、これを満たすことでどんなユーザーにも親切なフォームになります。
+
+#### スクリーンリーダーでの読み上げ
+
+`errorMessage` と `description` の両方が指定されている入力欄では、`errorMessage` を渡すと入力欄に `aria-invalid` が付き、エラーメッセージと description がどちらも `aria-describedby` で入力欄に関連付けられます。そのため入力欄にフォーカスが当たると、次の順で読み上げられます（例はラベル「お名前」・description「全角で入力してください」・エラーの場合）。
+
+> お名前、編集テキスト、**無効な入力**、全角で入力してください、エラー：お名前が入力されていません。
+
+- まず `aria-invalid` により「**無効な入力である**」という状態が伝わり、続いて description（入力ルール）、最後にエラー文が読まれます。エラー状態そのものは状態として通知されるため、色や枠線が見えなくてもエラーであることが分かります。
+- **エラー時も description（入力ルール）はあえて読み上げから外していません**。「全角で入力してください」のようなルールは、エラーを直している最中にこそ必要な情報だからです。エラーになった瞬間にルールが読まれなくなると、修正の手がかりを最も必要なタイミングで失ってしまいます。この挙動は [react-aria-components](https://react-spectrum.adobe.com/react-aria/TextField.html) の標準の関連付けに従っています。
+
+## 参考にした基準・デザインシステム
+
+- [WCAG 2.2 — 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html)
+- [WCAG 2.2 — 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)
+- [WCAG 2.2 — 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [WCAG 2.2 — 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html)
+- [WCAG 2.2 — 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html)
+- [react-aria — TextField](https://react-spectrum.adobe.com/react-aria/TextField.html)

--- a/packages/design-system/src/components/TextInput/TextInput.module.css
+++ b/packages/design-system/src/components/TextInput/TextInput.module.css
@@ -1,0 +1,72 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+}
+
+.label {
+  color: var(--text-default);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.requiredText {
+  color: var(--text-required);
+  font-weight: 400;
+}
+
+.input {
+  border: var(--border-width-md) solid var(--border-default);
+  border-radius: var(--border-radius-md);
+  background-color: var(--background-default);
+  color: var(--text-default);
+
+  /* a11y: line-height 28px + padding 8px でタッチターゲット44px以上を担保 */
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.75rem;
+}
+
+/* 入力値(--text-default)と区別しつつ白背景と4.5:1以上のコントラストを保つ */
+.input::placeholder {
+  color: var(--text-placeholder);
+}
+
+.input[data-hovered] {
+  border-color: var(--border-bold);
+}
+
+.input[data-focused] {
+  border-color: var(--border-bold);
+  outline: var(--border-width-lg) solid var(--border-bold);
+  outline-offset: 1px;
+}
+
+.input[data-invalid] {
+  border-color: var(--border-danger);
+}
+
+.input[data-disabled] {
+  background-color: var(--background-subtle);
+  border-color: var(--border-default);
+  color: var(--text-subtle);
+  cursor: not-allowed;
+}
+
+.description {
+  color: var(--text-subtle);
+  font-size: 0.875rem;
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  color: var(--text-danger);
+  font-size: 0.875rem;
+}
+
+.errorIcon {
+  flex-shrink: 0;
+}

--- a/packages/design-system/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/design-system/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, within } from "storybook/test";
+import { TextInput } from "./TextInput";
+
+const meta = {
+  title: "Design System/TextInput",
+  component: TextInput,
+  args: {
+    label: "お名前",
+    placeholder: "例：山田 太郎",
+    onChange: fn(),
+  },
+} satisfies Meta<typeof TextInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox", { name: "お名前" });
+    await expect(input).toHaveAttribute("placeholder", "例：山田 太郎");
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    description: "全角で入力してください",
+  },
+};
+
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox", { name: "お名前（必須）" });
+    await expect(input).toBeRequired();
+  },
+};
+
+export const Email: Story = {
+  args: {
+    label: "メールアドレス",
+    type: "email",
+    autoComplete: "email",
+    inputMode: "email",
+    placeholder: "例：taro@example.com",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox", { name: "メールアドレス" });
+    await expect(input).toHaveAttribute("type", "email");
+    await expect(input).toHaveAttribute("autocomplete", "email");
+    await expect(input).toHaveAttribute("inputmode", "email");
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    errorMessage:
+      "エラー：お名前が入力されていません。お名前を全角で入力してください。",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox", { name: /お名前/ });
+    await expect(input).toBeInvalid();
+    await expect(input).toHaveAccessibleDescription(
+      "エラー：お名前が入力されていません。お名前を全角で入力してください。",
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox", { name: "お名前" });
+    await expect(input).toBeDisabled();
+  },
+};

--- a/packages/design-system/src/components/TextInput/TextInput.tsx
+++ b/packages/design-system/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  TextField as AriaTextField,
+  composeRenderProps,
+  FieldError,
+  Input,
+  Label,
+  Text,
+  type TextFieldProps as AriaTextFieldProps,
+} from "react-aria-components";
+import { CautionIcon } from "../icons";
+import styles from "./TextInput.module.css";
+
+export type TextInputProps = Omit<
+  AriaTextFieldProps,
+  "isDisabled" | "isRequired" | "isInvalid" | "children"
+> & {
+  label: string;
+  description?: string;
+  errorMessage?: string;
+  /** 入力例。「例：」などを付けて渡します。なくても伝わる場合は省略してください。入力ルールの説明には description を使ってください */
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+};
+
+export function TextInput({
+  label,
+  description,
+  errorMessage,
+  placeholder,
+  disabled,
+  required,
+  className,
+  ...props
+}: TextInputProps) {
+  const isInvalid = Boolean(errorMessage);
+
+  return (
+    <AriaTextField
+      {...props}
+      isDisabled={disabled}
+      isRequired={required}
+      isInvalid={isInvalid || undefined}
+      className={composeRenderProps(className, (userClassName) =>
+        [styles.field, userClassName].filter(Boolean).join(" "),
+      )}
+    >
+      <Label className={styles.label}>
+        {label}
+        {required && <span className={styles.requiredText}>（必須）</span>}
+      </Label>
+      {description && (
+        <Text slot="description" className={styles.description}>
+          {description}
+        </Text>
+      )}
+      <Input className={styles.input} placeholder={placeholder} />
+      <FieldError className={styles.error}>
+        {isInvalid && (
+          <>
+            <CautionIcon
+              className={styles.errorIcon}
+              aria-hidden
+              focusable="false"
+            />
+            <span>{errorMessage}</span>
+          </>
+        )}
+      </FieldError>
+    </AriaTextField>
+  );
+}

--- a/packages/design-system/src/components/TextInput/index.ts
+++ b/packages/design-system/src/components/TextInput/index.ts
@@ -1,0 +1,2 @@
+export { TextInput } from "./TextInput";
+export type { TextInputProps } from "./TextInput";

--- a/packages/design-system/src/components/icons/generated/CautionIcon.tsx
+++ b/packages/design-system/src/components/icons/generated/CautionIcon.tsx
@@ -1,0 +1,9 @@
+import type { SVGProps } from "react";
+import type { IconProps } from "../Icon.types";
+const CautionIcon = ({
+  size = "1em",
+  ...props
+}: IconProps) => <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} fill="none" viewBox="0 0 24 24" {...props}><mask id="a" width={18} height={16} x={3} y={4} maskUnits="userSpaceOnUse" style={{
+    maskType: "luminance"
+  }}><path fill="#fff" fillRule="evenodd" stroke="#fff" strokeLinejoin="round" strokeWidth={2} d="M12.433 5.747a.5.5 0 0 0-.866 0l-7.132 12.32a.5.5 0 0 0 .432.751h14.266a.5.5 0 0 0 .433-.75z" clipRule="evenodd" /><path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M12 15.91v.363m0-6.182.003 3.637" /></mask><g mask="url(#a)"><path fill="currentColor" d="M3.273 3.182h17.454v17.455H3.273z" /></g></svg>;
+export default CautionIcon;

--- a/packages/design-system/src/components/icons/index.ts
+++ b/packages/design-system/src/components/icons/index.ts
@@ -2,6 +2,7 @@ export { default as ArrowBottomIcon } from "./generated/ArrowBottomIcon";
 export { default as ArrowLeftIcon } from "./generated/ArrowLeftIcon";
 export { default as ArrowRightIcon } from "./generated/ArrowRightIcon";
 export { default as ArrowUpIcon } from "./generated/ArrowUpIcon";
+export { default as CautionIcon } from "./generated/CautionIcon";
 export { default as CloseIcon } from "./generated/CloseIcon";
 export { default as GoogleIcon } from "./generated/GoogleIcon";
 export { default as MenuIcon } from "./generated/MenuIcon";

--- a/packages/design-system/src/components/icons/svg/caution.svg
+++ b/packages/design-system/src/components/icons/svg/caution.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_2182_1468" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="3" y="4" width="18" height="16">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.4327 5.74741C12.2401 5.41477 11.7599 5.41477 11.5673 5.74741L4.43451 18.0677C4.24153 18.401 4.48206 18.8182 4.86722 18.8182H19.1328C19.5179 18.8182 19.7585 18.401 19.5655 18.0677L12.4327 5.74741Z" fill="white" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+<path d="M12 15.9095V16.2731M12 10.0913L12.0029 13.7277" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</mask>
+<g mask="url(#mask0_2182_1468)">
+<path d="M3.27271 3.18213H20.7273V20.6367H3.27271V3.18213Z" fill="black"/>
+</g>
+</svg>

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components/Button";
+export * from "./components/TextInput";
 export * from "./components/icons";
 export type { IconProps } from "./components/icons/Icon.types";

--- a/packages/design-system/src/styles/tokens/semanticColor.css
+++ b/packages/design-system/src/styles/tokens/semanticColor.css
@@ -18,6 +18,8 @@
 
   --text-default: var(--neutral-5);
   --text-subtle: var(--neutral-20);
+  --text-placeholder: var(--neutral-40);
+  --text-required: var(--danger-40);
   --text-primary: var(--primary-30);
   --text-primary-action: var(--neutral-100);
   --text-danger: var(--danger-40);

--- a/patches/vite-plugin-storybook-nextjs@3.3.0.patch
+++ b/patches/vite-plugin-storybook-nextjs@3.3.0.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index c31da10233cac09d3b56635b7d82380557675c3d..3d202046b2ef7606f34dccfa8d4ad0f9643cdb45 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -3928,11 +3928,15 @@ async function vitePluginNextEnv(rootDir, nextConfigResolver) {
+   let getDefineEnv;
+   let isNext1540 = false;
+   try {
+-    getDefineEnv = (await import('next/dist/build/define-env.js')).getDefineEnv;
++    // Use require() instead of import() so the CJS named export resolves to the
++    // real function. Under Storybook + Vite the ESM interop of this CJS module
++    // yields an undefined `getDefineEnv` binding (Next 15.5), which then throws
++    // "getDefineEnv is not a function".
++    getDefineEnv = require('next/dist/build/define-env.js').getDefineEnv;
+     isNext1540 = true;
+   } catch (error) {
+     getDefineEnv = // @ts-expect-error - TODO: Ignoring because types are for >= 15.4.0
+-    (await import('next/dist/build/webpack/plugins/define-env-plugin.js')).getDefineEnv;
++    require('next/dist/build/webpack/plugins/define-env-plugin.js').getDefineEnv;
+   }
+   return {
+     name: "vite-plugin-storybook-nextjs-env",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vite-plugin-storybook-nextjs@3.3.0:
+    hash: 1f5a4563e6357cdbd9c39e94dd641f45d0204fad88f04cf2f1a4d4b8d941397c
+    path: patches/vite-plugin-storybook-nextjs@3.3.0.patch
+
 importers:
 
   .:
@@ -12391,7 +12396,7 @@ snapshots:
       storybook: 9.1.19(@testing-library/dom@10.4.0)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0))
       styled-jsx: 5.1.6(@babel/core@7.27.4)(react@18.3.1)
       vite: 7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@15.5.18(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.1))(storybook@9.1.19(@testing-library/dom@10.4.0)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)))(typescript@5.8.3)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0))
+      vite-plugin-storybook-nextjs: 3.3.0(patch_hash=1f5a4563e6357cdbd9c39e94dd641f45d0204fad88f04cf2f1a4d4b8d941397c)(next@15.5.18(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.1))(storybook@9.1.19(@testing-library/dom@10.4.0)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)))(typescript@5.8.3)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0))
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -16648,7 +16653,7 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite-plugin-storybook-nextjs@3.3.0(next@15.5.18(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.1))(storybook@9.1.19(@testing-library/dom@10.4.0)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)))(typescript@5.8.3)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)):
+  vite-plugin-storybook-nextjs@3.3.0(patch_hash=1f5a4563e6357cdbd9c39e94dd641f45d0204fad88f04cf2f1a4d4b8d941397c)(next@15.5.18(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.1))(storybook@9.1.19(@testing-library/dom@10.4.0)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)))(typescript@5.8.3)(vite@7.0.2(@types/node@20.17.57)(jiti@2.4.2)(sass@1.89.1)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "packages/*"
+patchedDependencies:
+  vite-plugin-storybook-nextjs@3.3.0: patches/vite-plugin-storybook-nextjs@3.3.0.patch


### PR DESCRIPTION
## What

react-aria-components ベースの `TextInput` コンポーネントを追加しました。ラベル・サポートテキスト（description）・エラーメッセージを1つのコンポーネントにまとめた1行テキスト入力欄です。

- `TextInput` 本体・CSS Module・Storybook stories / Docs(MDX)
- エラー表示用の `CautionIcon` を追加
- セマンティックカラートークンに `--text-placeholder` / `--text-required` を追加
- Storybook テスト用に `vite-plugin-storybook-nextjs` の patch を追加

## Why

- **アクセシビリティを担保した入力欄をデザインシステムとして提供するため。** react-aria をベースに、ラベルとの関連付け・必須表現（記号ではなく「（必須）」テキスト）・入力目的の指定（autoComplete / inputMode）・色に頼らないエラー表示（警告アイコン併記）を実装しています。
- **エラー時のスクリーンリーダー挙動を Docs に明記。** `errorMessage` を渡すと `aria-invalid` が付き、`description` とエラー文が両方 `aria-describedby` で関連付けられます。読み上げ順（無効な入力 → description → エラー文）と、エラー時も入力ルール(description)をあえて読み上げから外さない理由を Docs に記載しました。これは react-aria の標準の関連付けに沿った挙動です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)