### PR TITLE
:sparkles: feat: ドラッグ中に折りのプレビューを表示する

### DIFF
--- a/src/components/v2/OrigamiPost/doc/03-drag-and-fold-line.md
+++ b/src/components/v2/OrigamiPost/doc/03-drag-and-fold-line.md
@@ -35,6 +35,15 @@
 - D の位置と一致する候補（辺を自分自身に沿わせる無意味な折り）は除外し、同一位置の候補は集約する
 - 候補はドラッグ頂点に依存するため mousedown 時に計算し、mousemove では頂点スナップポイントと合わせて最も近いものへ吸着する（候補の描画はしない。吸着によるドラッグ中の点の移動がフィードバックになる）
 
+### 折りのプレビュー — computeFoldPreview / renderFoldPreview
+
+ドロップ前にどんな形に折れるかを視覚的に示すため、mousemove ごとに折りのプレビューを計算・描画する:
+
+- `computeFoldPreview` がドラッグ頂点と現在位置（吸着後）から折り線のスパンと、最前面の候補板を折り線で鏡映した「動く片」を返す
+- 毎フレーム呼ばれる前提の軽量な計算に限定し、折り操作の成立検証（枚数ごとの破れ判定や特殊折りの判定）はドロップ時にのみ行う。プレビューはあくまで「最前面の 1 枚がどんな形に折れるか」の目安
+- `renderFoldPreview` が動く片を半透明のゴースト（元の板と同じ高さ、polygonOffset 付き）で、折り線をドロップ後の確定表示（赤）と区別できるオレンジで描画する
+- 折り線が引けない位置（ドラッグ開始点への吸着など）ではプレビューを消し、mouseup でも必ず消す
+
 ### スナップまわりの既知の課題（未着手）
 
 折りが進むとスナップポイントが増え、操作性が下がる問題が確認されている:
@@ -86,6 +95,8 @@
 | `hooks/useDragDrop/useDragHandler.tsx` | mousedown / mousemove。レイキャストと点の移動 |
 | `hooks/useDragDrop/useDropHandler.tsx` | mouseup。折り線計算から分岐までの起点 |
 | `hooks/useDragDrop/renderPoint.tsx` | スナップポイント・ドラッグ中の点の描画 |
+| `hooks/useDragDrop/renderFoldPreview.ts` | ドラッグ中の折りプレビュー（折り線と動く片）の描画 |
+| `utils/computeFoldPreview/index.ts` | プレビュー形状（折り線スパンと鏡映後の動く片）の計算 |
 | `utils/snapToNearestSnapPoint/index.ts` | 吸着先への吸着と `SNAP_ATTRACTION_RADIUS` の定義 |
 | `utils/collectAlignmentSnapPoints/index.ts` | 辺の折り込み先（アライメント候補）の列挙 |
 | `utils/calculateFoldLine/index.ts` | 垂直二等分線としての折り線の導出 |

--- a/src/components/v2/OrigamiPost/hooks/useDragDrop/index.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useDragDrop/index.tsx
@@ -113,6 +113,7 @@ export const useDragDrop: UseDragDrop = ({
     cameraRef,
     rendererRef,
     raycasterRef,
+    origamiColor,
     currentBoards,
     snapPoints,
     setDraggedPoint,

--- a/src/components/v2/OrigamiPost/hooks/useDragDrop/renderFoldPreview.ts
+++ b/src/components/v2/OrigamiPost/hooks/useDragDrop/renderFoldPreview.ts
@@ -1,0 +1,73 @@
+import * as THREE from "three";
+import { BOARD_LAYER_OFFSET } from "../../constants";
+import { FoldPreview } from "../../utils/computeFoldPreview";
+import { createBoardMesh } from "../../utils/createBoardMesh";
+import { visualizeFoldLine } from "../../utils/visualizeFoldLine";
+import { disposeObject3D } from "../../utils/disposeObject3D";
+
+const PREVIEW_BOARD_NAME = "foldPreviewBoard";
+// "foldLine"で始まる名前にして、折り線の一括削除（removeFoldLine）でも消えるようにする
+const PREVIEW_LINE_NAME = "foldLinePreview";
+
+// 確定済みの板と区別できるよう、プレビューはゴースト風に薄く表示する
+const PREVIEW_BOARD_OPACITY = 0.45;
+const PREVIEW_LINE_COLOR = "#ff8c00";
+const PREVIEW_LINE_RADIUS = 0.4;
+
+/**
+ * ドラッグ中の折りプレビュー（折り線と鏡映後の動く片）をシーンに描画する
+ *
+ * @param props.scene - Three.jsのシーン
+ * @param props.preview - computeFoldPreviewの計算結果
+ * @param props.origamiColor - 折り紙の色
+ *
+ * @description
+ * - 毎フレーム呼ばれる前提。既存のプレビューを破棄してから描き直す
+ * - 動く片は元の板と同じ高さ（layer * BOARD_LAYER_OFFSET）に、
+ *   polygonOffsetで同一平面のちらつきを防ぎつつ半透明で表示する
+ * - 折り線はドロップ後の確定表示（赤）と区別できる色で表示する
+ */
+export const renderFoldPreview = (props: {
+  scene: THREE.Scene;
+  preview: FoldPreview;
+  origamiColor: string;
+}): void => {
+  const { scene, preview, origamiColor } = props;
+
+  removePreviewBoard(scene);
+
+  const boardMesh = createBoardMesh(preview.movingPolygon, origamiColor, {
+    name: PREVIEW_BOARD_NAME,
+    enablePolygonOffset: true,
+    opacity: PREVIEW_BOARD_OPACITY,
+  });
+  boardMesh.position.z = preview.layer * BOARD_LAYER_OFFSET;
+  scene.add(boardMesh);
+
+  visualizeFoldLine(scene, preview.foldLine.start, preview.foldLine.end, {
+    name: PREVIEW_LINE_NAME,
+    color: PREVIEW_LINE_COLOR,
+    radius: PREVIEW_LINE_RADIUS,
+  });
+};
+
+/**
+ * ドラッグ中の折りプレビューをシーンから削除する（リソースも破棄）
+ */
+export const removeFoldPreview = (scene: THREE.Scene): void => {
+  removePreviewBoard(scene);
+
+  const line = scene.getObjectByName(PREVIEW_LINE_NAME);
+  if (line) {
+    scene.remove(line);
+    disposeObject3D(line);
+  }
+};
+
+const removePreviewBoard = (scene: THREE.Scene): void => {
+  const board = scene.getObjectByName(PREVIEW_BOARD_NAME);
+  if (board) {
+    scene.remove(board);
+    disposeObject3D(board);
+  }
+};

--- a/src/components/v2/OrigamiPost/hooks/useDragDrop/useDragHandler.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useDragDrop/useDragHandler.tsx
@@ -6,7 +6,9 @@ import { LayeredBoard } from "../../types";
 import { SnapPoint } from "../../utils/collectSnapPoints";
 import { snapToNearestSnapPoint } from "../../utils/snapToNearestSnapPoint";
 import { collectAlignmentSnapPoints } from "../../utils/collectAlignmentSnapPoints";
+import { computeFoldPreview } from "../../utils/computeFoldPreview";
 import { renderDraggedPoint } from "./renderPoint";
+import { renderFoldPreview, removeFoldPreview } from "./renderFoldPreview";
 
 type UseDragHandler = (props: {
   canvasRef: React.MutableRefObject<HTMLCanvasElement | null>;
@@ -14,6 +16,7 @@ type UseDragHandler = (props: {
   cameraRef: React.MutableRefObject<THREE.PerspectiveCamera | null>;
   rendererRef: React.MutableRefObject<THREE.WebGLRenderer | null>;
   raycasterRef: React.MutableRefObject<THREE.Raycaster | null>;
+  origamiColor: string;
   currentBoards: LayeredBoard[];
   snapPoints: SnapPoint[];
   setDraggedPoint: (point: Point | null) => void;
@@ -31,7 +34,9 @@ type UseDragHandler = (props: {
  * - マウス移動時にドラッグ中の点の位置を更新。近くの吸着先（頂点の
  *   スナップポイント + 辺の折り込み先=アライメント候補）があれば
  *   その座標へ吸着させる
- * - マウスアップ時にドラッグ状態をリセット
+ * - ドラッグ中は折りのプレビュー（折り線と鏡映後の動く片）を毎フレーム
+ *   計算して表示し、ドロップ前にどんな形になるかを視覚的に示す
+ * - マウスアップ時にプレビューを消してドラッグ状態をリセット
  *
  * @param props.canvasRef - HTMLCanvasElementのref
  * @param props.sceneRef - THREE.Sceneのref
@@ -48,6 +53,7 @@ export const useDragHandler: UseDragHandler = ({
   cameraRef,
   rendererRef,
   raycasterRef,
+  origamiColor,
   currentBoards,
   snapPoints,
   setDraggedPoint,
@@ -150,6 +156,25 @@ export const useDragHandler: UseDragHandler = ({
         const draggedPointMesh = scene.getObjectByName("draggedPoint");
         if (draggedPointMesh) {
           draggedPointMesh.position.copy(snappedPosition);
+
+          // ドロップ時にどう折れるかのプレビュー（折り線と動く片）を表示する。
+          // どちら側から見ているかはドロップ時と同じくカメラ位置で判定する
+          const preview = computeFoldPreview({
+            boards: currentBoards,
+            dragVertex: new THREE.Vector3(
+              draggedPoint[0],
+              draggedPoint[1],
+              0
+            ),
+            draggedPosition: snappedPosition,
+            viewFront: camera.position.z > 0,
+          });
+          if (preview) {
+            renderFoldPreview({ scene, preview, origamiColor });
+          } else {
+            removeFoldPreview(scene);
+          }
+
           renderer.render(scene, camera);
         }
       }
@@ -159,7 +184,8 @@ export const useDragHandler: UseDragHandler = ({
       if (isDragging) {
         setIsDragging(false);
         isDragging = false;
-        // ドラッグ終了時の処理はuseDropHandlerで行う
+        // プレビューを消す。ドラッグ終了時の折り処理はuseDropHandlerで行う
+        removeFoldPreview(scene);
       }
     };
 
@@ -171,6 +197,8 @@ export const useDragHandler: UseDragHandler = ({
       canvas.removeEventListener("mousedown", handleMouseDown);
       canvas.removeEventListener("mousemove", handleMouseMove);
       canvas.removeEventListener("mouseup", handleMouseUp);
+      // ドラッグ途中で依存が変わった場合に備えてプレビューを消しておく
+      removeFoldPreview(scene);
     };
   }, [
     canvasRef,
@@ -178,6 +206,7 @@ export const useDragHandler: UseDragHandler = ({
     cameraRef,
     rendererRef,
     raycasterRef,
+    origamiColor,
     currentBoards,
     snapPoints,
     setDraggedPoint,

--- a/src/components/v2/OrigamiPost/utils/computeFoldPreview/index.test.ts
+++ b/src/components/v2/OrigamiPost/utils/computeFoldPreview/index.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { computeFoldPreview } from ".";
+import { LayeredBoard } from "../../types";
+import { findFoldCandidates } from "../applyFoldStep";
+import { createSquareBoard } from "../createSquareBoard";
+import { replayFoldSteps } from "../replayFoldSteps";
+import { craneNarrowedLegsSteps } from "../replayFoldSteps/craneFixture";
+
+const v = (x: number, y: number) => new THREE.Vector3(x, y, 0);
+
+const squareBoards = (): LayeredBoard[] => [
+  {
+    polygon: createSquareBoard(100),
+    sourcePolygon: createSquareBoard(100),
+    layer: 0,
+  },
+];
+
+const containsVertexNear = (
+  polygon: THREE.Vector3[],
+  point: THREE.Vector3
+): boolean =>
+  polygon.some(
+    (vertex) =>
+      Math.abs(vertex.x - point.x) < 1e-6 && Math.abs(vertex.y - point.y) < 1e-6
+  );
+
+describe("computeFoldPreview", () => {
+  it("正方形の角のドラッグで、動く片がドラッグ先の位置へ鏡映される", () => {
+    const preview = computeFoldPreview({
+      boards: squareBoards(),
+      dragVertex: v(50, -50),
+      draggedPosition: v(-50, -50),
+      viewFront: true,
+    });
+    expect(preview).not.toBeNull();
+    if (!preview) return;
+
+    // 折り線は垂直二等分線 x=0（正方形を縦に横切るスパン）
+    expect(preview.foldLine.start.x).toBeCloseTo(0);
+    expect(preview.foldLine.end.x).toBeCloseTo(0);
+
+    // ドラッグした頂点は鏡映によりドラッグ先の位置へ写る
+    expect(containsVertexNear(preview.movingPolygon, v(-50, -50))).toBe(true);
+    // 動く片は右半分の鏡映なので、元の右端の頂点は含まれない
+    expect(containsVertexNear(preview.movingPolygon, v(50, -50))).toBe(false);
+    expect(preview.layer).toBe(0);
+  });
+
+  it("ドラッグ位置が元位置と同じ場合はnull", () => {
+    expect(
+      computeFoldPreview({
+        boards: squareBoards(),
+        dragVertex: v(50, -50),
+        draggedPosition: v(50, -50),
+        viewFront: true,
+      })
+    ).toBeNull();
+  });
+
+  it("折り線が最前面の板を横切らない場合は板全体を鏡映する", () => {
+    // 最前面: 小さい三角形、背面: 大きい正方形（どちらも原点に頂点を持つ）
+    const triangle = [v(0, 0), v(10, 0), v(0, 10)];
+    const square = [v(0, 0), v(40, 0), v(40, 40), v(0, 40)];
+    const boards: LayeredBoard[] = [
+      { polygon: square, sourcePolygon: square, layer: 0 },
+      { polygon: triangle, sourcePolygon: triangle, layer: 1 },
+    ];
+
+    // 折り線 x+y=30 は三角形（x+y<=10）を横切らず、正方形だけを横切る
+    const preview = computeFoldPreview({
+      boards,
+      dragVertex: v(0, 0),
+      draggedPosition: v(30, 30),
+      viewFront: true,
+    });
+    expect(preview).not.toBeNull();
+    if (!preview) return;
+
+    expect(preview.movingPolygon.length).toBe(3);
+    expect(containsVertexNear(preview.movingPolygon, v(30, 30))).toBe(true);
+    expect(containsVertexNear(preview.movingPolygon, v(30, 20))).toBe(true);
+    expect(containsVertexNear(preview.movingPolygon, v(20, 30))).toBe(true);
+    expect(preview.layer).toBe(1);
+  });
+
+  it("鶴の先端のドラッグでも最前面の1枚のプレビューを返す", () => {
+    const boards = replayFoldSteps(
+      createSquareBoard(100),
+      craneNarrowedLegsSteps
+    );
+    const preview = computeFoldPreview({
+      boards,
+      dragVertex: v(50, 50),
+      draggedPosition: v(0, 40),
+      viewFront: true,
+    });
+    expect(preview).not.toBeNull();
+    if (!preview) return;
+
+    // ドラッグした先端はドラッグ先の位置へ写る
+    expect(containsVertexNear(preview.movingPolygon, v(0, 40))).toBe(true);
+    // 表示高さは最前面（視点側の先頭候補板）のレイヤー
+    const candidates = findFoldCandidates(boards, v(50, 50), true);
+    expect(preview.layer).toBe(candidates[0].layer);
+  });
+
+  it("候補板がない位置のドラッグはnull", () => {
+    expect(
+      computeFoldPreview({
+        boards: squareBoards(),
+        dragVertex: v(10, 10),
+        draggedPosition: v(0, 0),
+        viewFront: true,
+      })
+    ).toBeNull();
+  });
+});

--- a/src/components/v2/OrigamiPost/utils/computeFoldPreview/index.ts
+++ b/src/components/v2/OrigamiPost/utils/computeFoldPreview/index.ts
@@ -1,0 +1,79 @@
+import * as THREE from "three";
+import { Board, FoldLine, LayeredBoard } from "../../types";
+import { calculateFoldLine } from "../calculateFoldLine";
+import { calculateFoldLineSpan } from "../calculateFoldLineSpan";
+import { findFoldCandidates } from "../applyFoldStep";
+import { separateBoard } from "../separateBoard";
+import { selectMovingBoard } from "../selectMovingBoard";
+import { mirrorBoardAcrossLine } from "../rotateBoard";
+
+/**
+ * ドラッグ中の折りプレビュー
+ */
+export interface FoldPreview {
+  /** 折り線のスパン（全候補板を覆う表示用の区間） */
+  foldLine: FoldLine;
+  /** 折り線で鏡映した後の動く片（最前面の候補板のみ） */
+  movingPolygon: Board;
+  /** 動く片の元になった板のレイヤー（表示高さの計算に使用） */
+  layer: number;
+}
+
+/**
+ * ドラッグ中の位置から折りのプレビュー形状を計算する
+ *
+ * @param props.boards - 現在の板の一覧
+ * @param props.dragVertex - ドラッグした頂点の元位置
+ * @param props.draggedPosition - ドラッグ中の現在位置（吸着後）
+ * @param props.viewFront - 表側（+Z側）から見ているか
+ * @returns 折り線スパンと、最前面の候補板を折り線で鏡映した片。
+ *          折り線が引けない・候補板がない場合はnull
+ *
+ * @description
+ * 毎フレーム呼ばれる前提の軽量な計算に限定する。折り操作の成立検証
+ * （枚数ごとの破れ判定や特殊折りの判定）はドロップ時にのみ行い、
+ * プレビューは「最前面の1枚がどんな形に折れるか」だけを示す:
+ * - 折り線が最前面の板を横切る場合はドラッグ頂点側の片を鏡映する
+ * - 横切らない場合（板全体がドラッグ頂点側にある場合）は板全体を鏡映する
+ */
+export const computeFoldPreview = (props: {
+  boards: LayeredBoard[];
+  dragVertex: THREE.Vector3;
+  draggedPosition: THREE.Vector3;
+  viewFront: boolean;
+}): FoldPreview | null => {
+  const { boards, dragVertex, draggedPosition, viewFront } = props;
+
+  const foldLineInfo = calculateFoldLine(dragVertex, draggedPosition);
+  if (!foldLineInfo) return null;
+
+  const candidates = findFoldCandidates(boards, dragVertex, viewFront);
+  if (candidates.length === 0) return null;
+
+  const span = calculateFoldLineSpan(
+    foldLineInfo.midpoint,
+    foldLineInfo.direction,
+    candidates.map((candidate) => candidate.polygon)
+  );
+  if (!span) return null;
+
+  const top = candidates[0];
+  const separated = separateBoard(top.polygon, top.sourcePolygon, span);
+  if (!separated) {
+    // 折り線が最前面の板を横切らない場合は板全体が動く
+    return {
+      foldLine: span,
+      movingPolygon: mirrorBoardAcrossLine(top.polygon, span),
+      layer: top.layer,
+    };
+  }
+
+  const selected = selectMovingBoard(separated, dragVertex, span);
+  if (!selected) return null;
+
+  return {
+    foldLine: span,
+    movingPolygon: mirrorBoardAcrossLine(selected.movingPiece.polygon, span),
+    layer: top.layer,
+  };
+};

--- a/src/components/v2/OrigamiPost/utils/createBoardMesh/index.test.ts
+++ b/src/components/v2/OrigamiPost/utils/createBoardMesh/index.test.ts
@@ -44,6 +44,21 @@ describe("createBoardMesh", () => {
     expect(material.polygonOffset).toBe(false);
   });
 
+  it("opacity指定時は不透明度が上書きされる", () => {
+    const group = createBoardMesh(createTriangleBoard(), "#4A90E2", {
+      opacity: 0.45,
+    });
+    const mesh = group.children[0];
+
+    if (!(mesh instanceof THREE.Mesh)) throw new Error("Mesh not found");
+    const material = mesh.material;
+    if (!(material instanceof THREE.MeshLambertMaterial)) {
+      throw new Error("MeshLambertMaterial not found");
+    }
+
+    expect(material.opacity).toBe(0.45);
+  });
+
   it("enablePolygonOffset指定時はpolygonOffsetが有効になる", () => {
     const group = createBoardMesh(createTriangleBoard(), "#4A90E2", {
       enablePolygonOffset: true,

--- a/src/components/v2/OrigamiPost/utils/createBoardMesh/index.ts
+++ b/src/components/v2/OrigamiPost/utils/createBoardMesh/index.ts
@@ -9,6 +9,8 @@ import { Board } from "../../types";
  * @param options.name - Groupに設定する名前
  * @param options.enablePolygonOffset - 深度値をずらして同一平面での
  *        ちらつき（z-fighting）を防ぐ。折りで動く板に指定する
+ * @param options.opacity - 板の不透明度（デフォルト: 0.9。
+ *        ドラッグ中のプレビューのようなゴースト表示では下げる）
  * @returns 板メッシュと枠線をまとめたGroup
  *
  * @description
@@ -20,7 +22,11 @@ import { Board } from "../../types";
 export const createBoardMesh = (
   board: Board,
   color: string,
-  options: { name?: string; enablePolygonOffset?: boolean } = {}
+  options: {
+    name?: string;
+    enablePolygonOffset?: boolean;
+    opacity?: number;
+  } = {}
 ): THREE.Group => {
   const shape = new THREE.Shape();
   shape.moveTo(board[0].x, board[0].y);
@@ -34,7 +40,7 @@ export const createBoardMesh = (
     color,
     side: THREE.DoubleSide,
     transparent: true,
-    opacity: 0.9,
+    opacity: options.opacity ?? 0.9,
     ...(options.enablePolygonOffset
       ? { polygonOffset: true, polygonOffsetFactor: -1, polygonOffsetUnits: -1 }
       : {}),


### PR DESCRIPTION
## What
頂点のドラッグ中に、折り線と折った後の形（動く片）をプレビュー表示するようにした

- `computeFoldPreview` でドラッグ位置から折り線スパンと鏡映後の動く片を毎フレーム計算
- `renderFoldPreview` で動く片を半透明ゴースト、折り線を確定表示（赤）と区別できるオレンジで描画
- `createBoardMesh` に `opacity` オプションを追加

## Why
これまで折りの結果はドロップして初めて分かったため、ドロップ前にどんな形になるかを視覚的にフィードバックして操作しやすくするため

🤖 Generated with [Claude Code](https://claude.com/claude-code)