### PR TITLE
:sparkles: feat: 折るたびに視点を紙の中心に追従させる

### DIFF
--- a/src/components/v2/OrigamiPost/doc/01-architecture.md
+++ b/src/components/v2/OrigamiPost/doc/01-architecture.md
@@ -17,7 +17,8 @@ OrigamiPostV2 (index.tsx)
 │   └── commenceSquashFold 開いて畳むの確定処理（→ 09）
 ├── useFoldAnimation    foldingフェーズの180度折りアニメーション
 │                       （通常: ピボットGroup回転 / 開いて畳む: モーフ板の頂点書き換え）
-├── useFlipView         視点をY軸周りに180度回す「裏返し」
+├── useFlipView         視点を垂直軸周りに180度回す「裏返し」
+├── useCameraFocus      折るたびに移動する紙の中心へ回転の中心とカメラを追従
 ├── Toolbar/            Undo・Redo・裏返しボタン
 └── FoldCountSelector/  折り方（枚数・開いて畳む）の選択カード（selectingフェーズのみ表示）
 ```
@@ -89,5 +90,6 @@ scene                                scene
 | `hooks/useDragDrop/index.tsx` | ドラッグ&ドロップの統合フック |
 | `hooks/useFoldAnimation/index.tsx` | 折りアニメーション |
 | `hooks/useFlipView/index.tsx` | 視点の裏返し |
+| `hooks/useCameraFocus/index.tsx` | 折り紙の中心への視点追従 |
 | `Toolbar/index.tsx` | Undo / Redo / 裏返しボタン |
 | `FoldCountSelector/index.tsx` | 折り方（枚数・開いて畳む）の選択カード |

--- a/src/components/v2/OrigamiPost/doc/08-rendering-animation.md
+++ b/src/components/v2/OrigamiPost/doc/08-rendering-animation.md
@@ -73,9 +73,15 @@ Group の position を折り線上の点に置き、中の板メッシュを逆�
 
 開いて畳むの動く片は途中経過で厳密な平面でなくなるため、`ShapeGeometry` の作り直しではなく `BufferGeometry` の position 属性書き換えで動かす。三角形分割（`ShapeUtils.triangulateShape`）は頂点数が変わらない前提で作成時に一度だけ行い、面と枠線（LineLoop）は position 属性を共有するため1回の書き換えで両方動く。頂点が毎フレーム動くのでフラスタムカリングは無効化する。
 
+## 視点の中心追従 — useCameraFocus
+
+折るたびに紙の占める領域は移動するが、回転の中心（OrbitControls の `target`）が原点のままだと、ビューモードや裏返しの回転が紙の中心からずれて違和感が出る。板群が変わったら（折りの確定・Undo・Redo）、板群のバウンディングボックス中心（`computeBoardsCenter`、XY 平面上）へ `target` を移し、カメラも同じ差分だけ rAF + easeInOutCubic（400ms）で平行移動させる。純粋な平行移動なのでカメラの向きは変わらず、紙が画面中央へ滑らかにスライドする。
+
+中心はバウンディングボックスで決める（頂点の平均だと折りによる頂点の細分に引きずられるため）。カメラは XY 方向にしか動かないので z の符号は変わらず、`viewFront` 判定（[05](./05-multi-board-folding.md)）には影響しない。
+
 ## 裏返し — useFlipView
 
-カメラを Y 軸周りに 180 度、rAF + easeInOutCubic（600ms）で回転させる。**折り紙のデータは一切変更しない**。裏側から見た状態での折りはドロップ時のカメラ位置から判定する（[05](./05-multi-board-folding.md)）。アニメーション中は OrbitControls とツールバーの各ボタンを無効化する。
+カメラを回転中心（OrbitControls の `target`）を通る垂直軸周りに 180 度、rAF + easeInOutCubic（600ms）で回転させる。**折り紙のデータは一切変更しない**。裏側から見た状態での折りはドロップ時のカメラ位置から判定する（[05](./05-multi-board-folding.md)）。アニメーション中は OrbitControls とツールバーの各ボタンを無効化する。
 
 ## 折り線の可視化 — visualizeFoldLine
 
@@ -98,6 +104,8 @@ Group の position を折り線上の点に置き、中の板メッシュを逆�
 | `hooks/useFoldAnimation/index.tsx` | 180 度折りアニメーション（fold / squash の分岐） |
 | `utils/createMorphBoardMesh/index.ts` | モーフ板の生成と頂点書き換え |
 | `utils/computeSquashAnimationPositions/index.ts` | 開いて畳むの途中経過座標（[09](./09-squash-fold.md)） |
+| `hooks/useCameraFocus/index.tsx` | 折り紙の中心への視点追従 |
+| `utils/computeBoardsCenter/index.ts` | 板群のバウンディングボックス中心 |
 | `hooks/useFlipView/index.tsx` | 視点の裏返し |
 | `utils/easeInOutCubic/index.ts` | イージング関数（折り・裏返しで共用） |
 | `utils/visualizeFoldLine/index.ts` | 折り線シリンダーの描画・削除 |

--- a/src/components/v2/OrigamiPost/hooks/index.ts
+++ b/src/components/v2/OrigamiPost/hooks/index.ts
@@ -7,6 +7,7 @@
  * - useFoldAnimation: 折り線を軸とした180度折りアニメーション
  * - useFlipView: 折り紙を裏返す視点回転
  * - useViewMode: 確認用の回転視点（ビューモード）
+ * - useCameraFocus: 折り紙の中心への視点追従
  */
 export { useInitScene } from "./useInitScene";
 export { useDragDrop } from "./useDragDrop";
@@ -14,3 +15,4 @@ export type { FoldChoice } from "./useDragDrop";
 export { useFoldAnimation } from "./useFoldAnimation";
 export { useFlipView } from "./useFlipView";
 export { useViewMode } from "./useViewMode";
+export { useCameraFocus } from "./useCameraFocus";

--- a/src/components/v2/OrigamiPost/hooks/useCameraFocus/index.test.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useCameraFocus/index.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/Addons.js";
+import { useCameraFocus } from "./index";
+import { LayeredBoard } from "../../types";
+
+// requestAnimationFrameを手動で進められるようにフェイク化する
+let rafCallbacks: FrameRequestCallback[] = [];
+
+const flushAnimationFrame = (time: number) => {
+  const callbacks = rafCallbacks;
+  rafCallbacks = [];
+  callbacks.forEach((callback) => callback(time));
+};
+
+const createBoard = (vertices: [number, number][]): LayeredBoard => ({
+  polygon: vertices.map(([x, y]) => new THREE.Vector3(x, y, 0)),
+  sourcePolygon: vertices.map(([x, y]) => new THREE.Vector3(x, y, 0)),
+  layer: 0,
+});
+
+const createCameraAndControls = () => {
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.set(0, 0, 150);
+  const controls = new OrbitControls(camera, document.createElement("canvas"));
+  return { camera, controls };
+};
+
+describe("useCameraFocus", () => {
+  beforeEach(() => {
+    rafCallbacks = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback): number => {
+        rafCallbacks.push(callback);
+        return rafCallbacks.length;
+      }
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("板群の中心へ回転の中心とカメラが平行移動する", () => {
+    const { camera, controls } = createCameraAndControls();
+    const boards = [
+      createBoard([
+        [0, 0],
+        [100, 0],
+        [100, 50],
+        [0, 50],
+      ]),
+    ];
+
+    renderHook(() =>
+      useCameraFocus({
+        cameraRef: { current: camera },
+        controlsRef: { current: controls },
+        currentBoards: boards,
+      })
+    );
+
+    act(() => {
+      flushAnimationFrame(0);
+      flushAnimationFrame(400);
+    });
+
+    expect(controls.target.x).toBeCloseTo(50);
+    expect(controls.target.y).toBeCloseTo(25);
+    // カメラも同じ差分だけ動く（純粋な平行移動で向きは変わらない）
+    expect(camera.position.x).toBeCloseTo(50);
+    expect(camera.position.y).toBeCloseTo(25);
+    expect(camera.position.z).toBeCloseTo(150);
+  });
+
+  it("中心がすでに一致している場合は視点を動かさない", () => {
+    const { camera, controls } = createCameraAndControls();
+    const boards = [
+      createBoard([
+        [-50, -50],
+        [50, -50],
+        [50, 50],
+        [-50, 50],
+      ]),
+    ];
+
+    renderHook(() =>
+      useCameraFocus({
+        cameraRef: { current: camera },
+        controlsRef: { current: controls },
+        currentBoards: boards,
+      })
+    );
+
+    expect(rafCallbacks).toHaveLength(0);
+  });
+
+  it("板群が変わるたびに新しい中心へ追従する", () => {
+    const { camera, controls } = createCameraAndControls();
+    const firstBoards = [
+      createBoard([
+        [0, 0],
+        [100, 0],
+        [100, 100],
+        [0, 100],
+      ]),
+    ];
+    const secondBoards = [
+      createBoard([
+        [-100, -100],
+        [0, -100],
+        [0, 0],
+        [-100, 0],
+      ]),
+    ];
+
+    const { rerender } = renderHook(
+      ({ boards }) =>
+        useCameraFocus({
+          cameraRef: { current: camera },
+          controlsRef: { current: controls },
+          currentBoards: boards,
+        }),
+      { initialProps: { boards: firstBoards } }
+    );
+
+    act(() => {
+      flushAnimationFrame(0);
+      flushAnimationFrame(400);
+    });
+
+    rerender({ boards: secondBoards });
+
+    act(() => {
+      flushAnimationFrame(1000);
+      flushAnimationFrame(1400);
+    });
+
+    expect(controls.target.x).toBeCloseTo(-50);
+    expect(controls.target.y).toBeCloseTo(-50);
+    expect(camera.position.x).toBeCloseTo(-50);
+    expect(camera.position.y).toBeCloseTo(-50);
+    expect(camera.position.z).toBeCloseTo(150);
+  });
+});

--- a/src/components/v2/OrigamiPost/hooks/useCameraFocus/index.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useCameraFocus/index.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/Addons.js";
+import { LayeredBoard } from "../../types";
+import { computeBoardsCenter } from "../../utils/computeBoardsCenter";
+import { easeInOutCubic } from "../../utils/easeInOutCubic";
+
+/** 視点の平行移動アニメーションの所要時間（ミリ秒） */
+const PAN_DURATION_MS = 400;
+
+/** これ未満の移動量では視点を動かさない（微小なズレの無視） */
+const MIN_PAN_DISTANCE = 0.01;
+
+type UseCameraFocus = (props: {
+  cameraRef: React.MutableRefObject<THREE.PerspectiveCamera | null>;
+  controlsRef: React.MutableRefObject<OrbitControls | null>;
+  currentBoards: LayeredBoard[];
+}) => void;
+
+/**
+ * 折り紙の中心に視点を追従させるカスタムフック
+ *
+ * @description
+ * - 折るたびに紙の占める領域が移動するが、回転の中心
+ *   （OrbitControlsのtarget）が原点のままだと、ビューモードや
+ *   裏返しの回転が紙の中心からずれて違和感が出る
+ * - 板群が変わったら（折りの確定・Undo・Redo）、板群の
+ *   バウンディングボックス中心へOrbitControlsのtargetを移し、
+ *   カメラも同じ差分だけ平行移動させる。純粋な平行移動なので
+ *   カメラの向きは変わらず、紙が画面中央へ滑らかにスライドする
+ *
+ * @param props.cameraRef - THREE.PerspectiveCameraのref
+ * @param props.controlsRef - OrbitControlsのref
+ * @param props.currentBoards - 現在の板群
+ */
+export const useCameraFocus: UseCameraFocus = ({
+  cameraRef,
+  controlsRef,
+  currentBoards,
+}) => {
+  const animationFrameIdRef = useRef(0);
+
+  useEffect(() => {
+    const camera = cameraRef.current;
+    const controls = controlsRef.current;
+    if (!camera || !controls) return;
+
+    const center = computeBoardsCenter(currentBoards);
+    const delta = center.clone().sub(controls.target);
+    if (delta.length() < MIN_PAN_DISTANCE) return;
+
+    const startTarget = controls.target.clone();
+    const startPosition = camera.position.clone();
+    let startTime: number | null = null;
+
+    const animate = (time: number) => {
+      if (startTime === null) startTime = time;
+
+      const progress = Math.min((time - startTime) / PAN_DURATION_MS, 1);
+      const offset = delta.clone().multiplyScalar(easeInOutCubic(progress));
+
+      controls.target.copy(startTarget.clone().add(offset));
+      camera.position.copy(startPosition.clone().add(offset));
+      controls.update();
+
+      if (progress < 1) {
+        animationFrameIdRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrameIdRef.current = requestAnimationFrame(animate);
+
+    return () => cancelAnimationFrame(animationFrameIdRef.current);
+  }, [cameraRef, controlsRef, currentBoards]);
+};

--- a/src/components/v2/OrigamiPost/hooks/useFlipView/index.test.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useFlipView/index.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/Addons.js";
 import { useFlipView } from "./index";
 
 // requestAnimationFrameを手動で進められるようにフェイク化する
@@ -57,6 +58,33 @@ describe("useFlipView", () => {
     expect(camera.position.y).toBeCloseTo(0);
     expect(camera.position.z).toBeCloseTo(-150);
     expect(result.current.isFlipping).toBe(false);
+  });
+
+  it("回転の中心が移動していても、その中心を通る軸周りに裏返る", () => {
+    const camera = createCamera();
+    camera.position.set(30, 0, 150);
+    const controls = new OrbitControls(
+      camera,
+      document.createElement("canvas")
+    );
+    controls.target.set(30, 0, 0);
+
+    const { result } = renderHook(() =>
+      useFlipView({
+        cameraRef: { current: camera },
+        controlsRef: { current: controls },
+      })
+    );
+
+    act(() => result.current.flipView());
+    act(() => {
+      flushAnimationFrame(0);
+      flushAnimationFrame(600);
+    });
+
+    expect(camera.position.x).toBeCloseTo(30);
+    expect(camera.position.y).toBeCloseTo(0);
+    expect(camera.position.z).toBeCloseTo(-150);
   });
 
   it("もう一度裏返すと表側へ戻る", () => {

--- a/src/components/v2/OrigamiPost/hooks/useFlipView/index.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useFlipView/index.tsx
@@ -20,7 +20,8 @@ type UseFlipView = (props: {
  * 折り紙を裏返す視点回転を管理するカスタムフック
  *
  * @description
- * - カメラをY軸周りに180度、rAF + easeInOutCubicで回転させる
+ * - カメラを回転中心（OrbitControlsのtarget）を通る垂直軸周りに
+ *   180度、rAF + easeInOutCubicで回転させる
  *   （描画はuseInitSceneのアニメーションループが毎フレーム行う）
  * - 折り紙のデータは変更しない。裏返した状態での折りは、ドロップ時の
  *   カメラ位置（zの符号）から視点を判定して処理する
@@ -49,7 +50,11 @@ export const useFlipView: UseFlipView = ({ cameraRef, controlsRef }) => {
     if (controls) controls.enabled = false;
     setIsFlipping(true);
 
-    const startPosition = camera.position.clone();
+    // 回転中心は紙の中心に追従しているOrbitControlsのtarget
+    const pivot = controls
+      ? controls.target.clone()
+      : new THREE.Vector3(0, 0, 0);
+    const startOffset = camera.position.clone().sub(pivot);
     const yAxis = new THREE.Vector3(0, 1, 0);
     let startTime: number | null = null;
 
@@ -60,9 +65,9 @@ export const useFlipView: UseFlipView = ({ cameraRef, controlsRef }) => {
       const angle = easeInOutCubic(progress) * Math.PI;
 
       camera.position.copy(
-        startPosition.clone().applyAxisAngle(yAxis, angle)
+        pivot.clone().add(startOffset.clone().applyAxisAngle(yAxis, angle))
       );
-      camera.lookAt(0, 0, 0);
+      camera.lookAt(pivot);
 
       if (progress < 1) {
         animationFrameIdRef.current = requestAnimationFrame(animate);

--- a/src/components/v2/OrigamiPost/hooks/useViewMode/index.tsx
+++ b/src/components/v2/OrigamiPost/hooks/useViewMode/index.tsx
@@ -55,7 +55,7 @@ export const useViewMode: UseViewMode = ({
       const savedPosition = savedCameraPositionRef.current;
       if (savedPosition) {
         camera.position.copy(savedPosition);
-        camera.lookAt(0, 0, 0);
+        camera.lookAt(controls.target);
         controls.update();
       }
       savedCameraPositionRef.current = null;

--- a/src/components/v2/OrigamiPost/index.tsx
+++ b/src/components/v2/OrigamiPost/index.tsx
@@ -9,6 +9,7 @@ import {
   useFoldAnimation,
   useFlipView,
   useViewMode,
+  useCameraFocus,
 } from "./hooks";
 import {
   FoldStep,
@@ -228,6 +229,13 @@ export const OrigamiPostV2: React.FC<OrigamiPostV2Props> = ({
     width,
     height,
     cameraPosition,
+  });
+
+  // 折り紙の中心への視点追従（回転の中心を紙の中心に保つ）
+  useCameraFocus({
+    cameraRef,
+    controlsRef,
+    currentBoards,
   });
 
   // ドラッグ&ドロップ機能（板の描画とスナップポイントの管理を含む）

--- a/src/components/v2/OrigamiPost/utils/computeBoardsCenter/index.test.ts
+++ b/src/components/v2/OrigamiPost/utils/computeBoardsCenter/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import * as THREE from "three";
+import { computeBoardsCenter } from "./index";
+import { LayeredBoard } from "../../types";
+
+const createBoard = (
+  vertices: [number, number][],
+  layer = 0
+): LayeredBoard => ({
+  polygon: vertices.map(([x, y]) => new THREE.Vector3(x, y, 0)),
+  sourcePolygon: vertices.map(([x, y]) => new THREE.Vector3(x, y, 0)),
+  layer,
+});
+
+describe("computeBoardsCenter", () => {
+  it("板が無い場合は原点を返す", () => {
+    const center = computeBoardsCenter([]);
+    expect(center.x).toBe(0);
+    expect(center.y).toBe(0);
+    expect(center.z).toBe(0);
+  });
+
+  it("1枚の板のバウンディングボックス中心を返す", () => {
+    const board = createBoard([
+      [0, 0],
+      [100, 0],
+      [100, 50],
+      [0, 50],
+    ]);
+
+    const center = computeBoardsCenter([board]);
+    expect(center.x).toBeCloseTo(50);
+    expect(center.y).toBeCloseTo(25);
+    expect(center.z).toBe(0);
+  });
+
+  it("複数の板をまたいだバウンディングボックスの中心を返す", () => {
+    const left = createBoard([
+      [-100, -50],
+      [-50, -50],
+      [-50, 0],
+    ]);
+    const right = createBoard(
+      [
+        [0, 0],
+        [100, 0],
+        [100, 150],
+      ],
+      1
+    );
+
+    const center = computeBoardsCenter([left, right]);
+    expect(center.x).toBeCloseTo(0);
+    expect(center.y).toBeCloseTo(50);
+  });
+
+  it("頂点の密度に偏りがあっても中心はバウンディングボックスで決まる", () => {
+    // 左端に頂点を密集させても、範囲が同じなら中心は変わらない
+    const board = createBoard([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100],
+    ]);
+
+    const center = computeBoardsCenter([board]);
+    expect(center.x).toBeCloseTo(50);
+    expect(center.y).toBeCloseTo(50);
+  });
+});

--- a/src/components/v2/OrigamiPost/utils/computeBoardsCenter/index.ts
+++ b/src/components/v2/OrigamiPost/utils/computeBoardsCenter/index.ts
@@ -1,0 +1,30 @@
+import * as THREE from "three";
+import { LayeredBoard } from "../../types";
+
+/**
+ * 板群全体のバウンディングボックス中心を求める
+ *
+ * @description
+ * - 全頂点のバウンディングボックスの中心をXY平面上（z=0）で返す
+ * - 頂点の平均（重心）ではなくバウンディングボックスを使うのは、
+ *   折りによる頂点の細分（密度の偏り）に影響されず、見た目の
+ *   中央に一致させるため
+ * - 板が無い場合は原点を返す
+ *
+ * @param boards - 現在の板群
+ * @returns 板群の中心座標（z=0）
+ */
+export const computeBoardsCenter = (boards: LayeredBoard[]): THREE.Vector3 => {
+  const box = new THREE.Box2();
+
+  for (const board of boards) {
+    for (const vertex of board.polygon) {
+      box.expandByPoint(new THREE.Vector2(vertex.x, vertex.y));
+    }
+  }
+
+  if (box.isEmpty()) return new THREE.Vector3(0, 0, 0);
+
+  const center = box.getCenter(new THREE.Vector2());
+  return new THREE.Vector3(center.x, center.y, 0);
+};


### PR DESCRIPTION
## Summary
- 折るたびに紙の占める領域が移動するが、OrbitControls の回転中心（target）が原点に固定されたままだったため、ビューモードや裏返しの回転が紙の中心からずれて違和感があった
- `computeBoardsCenter` で板群のバウンディングボックス中心を算出し、`useCameraFocus` が折りの確定・Undo・Redo のたびに target とカメラを同じ差分だけ平行移動させて追従させる
- `useFlipView` の裏返し回転軸・`useViewMode` の lookAt も target 基準に変更し、常に紙の中心を軸に回転するようにした

## Test plan
- [x] `pnpm vitest run src/components/v2/OrigamiPost` — 38ファイル / 221件パス
- [x] `pnpm lint` — 既存の無関係な警告のみ
- [ ] ブラウザでの目視確認（複数回折って裏返し・ビューモードで違和感がないか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)